### PR TITLE
Promiscuous basic auth

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,8 @@
 Version NEXT
 ============
  * Fixed bug with using form data representations with authentication.
+ * Added PromiscuousBasicAuthenticator to support basic authentication
+   with servers that do not return challenge headers.
 
 Version 1.0.0
 ============

--- a/Manifest
+++ b/Manifest
@@ -6,6 +6,7 @@ Rakefile
 lib/resourceful.rb
 lib/resourceful/abstract_form_data.rb
 lib/resourceful/authentication_manager.rb
+lib/resourceful/promiscuous_basic_authenticator.rb
 lib/resourceful/cache_manager.rb
 lib/resourceful/exceptions.rb
 lib/resourceful/header.rb

--- a/lib/resourceful.rb
+++ b/lib/resourceful.rb
@@ -15,6 +15,7 @@ module Resourceful
   autoload :MultipartFormData, 'resourceful/multipart_form_data'
   autoload :UrlencodedFormData, 'resourceful/urlencoded_form_data'
   autoload :StubbedResourceProxy, 'resourceful/stubbed_resource_proxy'
+  autoload :PromiscuousBasicAuthenticator, 'resourceful/promiscuous_basic_authenticator'
 
   extend Simple
 end

--- a/lib/resourceful/authentication_manager.rb
+++ b/lib/resourceful/authentication_manager.rb
@@ -27,7 +27,7 @@ module Resourceful
 
   end
 
-  class BasicAuthenticator
+  class BasicAuthenticator 
 
     def initialize(realm, username, password)
       @realm, @username, @password = realm, username, password
@@ -57,7 +57,6 @@ module Resourceful
     def credentials
       HTTPAuth::Basic.pack_authorization(@username, @password)
     end
-
   end
 
   class DigestAuthenticator

--- a/lib/resourceful/promiscuous_basic_authenticator.rb
+++ b/lib/resourceful/promiscuous_basic_authenticator.rb
@@ -1,0 +1,18 @@
+module Resourceful  
+  # This class provides HTTP basic authentication without regard to
+  # the realm of receiving resource.  This will send your username and
+  # password with any request made while it is in play.
+  class PromiscuousBasicAuthenticator < BasicAuthenticator
+    def initialize(username, password)
+      super(nil, username, password)
+    end
+    
+    def valid_for?(challenge_response)
+      true
+    end
+
+    def can_handle?(request)
+      true
+    end
+  end
+end

--- a/spec/resourceful/promiscuous_basic_authenticator_spec.rb
+++ b/spec/resourceful/promiscuous_basic_authenticator_spec.rb
@@ -1,0 +1,30 @@
+require File.expand_path("../spec_helper", File.dirname(__FILE__))
+
+describe Resourceful::PromiscuousBasicAuthenticator do 
+  before do 
+    @authenticator = Resourceful::PromiscuousBasicAuthenticator.new('jim', 'mypasswd')
+  end
+
+  it "should always claim to be valid for a challenge response" do 
+    challenge_resp = mock("a challenge response")
+    @authenticator.valid_for?(challenge_resp).should eql(true)
+  end
+
+  it "should always claim to handle any request" do 
+    a_req = mock("a  request")
+    @authenticator.valid_for?(a_req).should eql(true)
+  end
+
+  it "be creatable with just a username and password" do 
+    Resourceful::PromiscuousBasicAuthenticator.new('jim', 'mypasswd').should be_instance_of(Resourceful::PromiscuousBasicAuthenticator)
+  end
+
+  it "add credentials to request" do 
+    header = mock('header')
+    header.should_receive(:[]=).with("Authorization", "Basic amltOm15cGFzc3dk")
+    a_req = mock("a  request", :header => header)
+
+    @authenticator.add_credentials_to(a_req)
+  end
+
+end


### PR DESCRIPTION
Add ability to send basic auth information with every request (even before getting a 401).  Allows resourceful to work with (buggy) servers that support basic auth but do not respond with 401.
